### PR TITLE
feat: consolidate to single app container with optional DB and Redis

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -47,12 +47,11 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Compute project identifiers
+      - name: Compute image name
         shell: bash
         run: |
-          SLUG="$(echo "${{ github.event.repository.name }}" \
-            | tr '[:upper:]' '[:lower:]')"
-          echo "APP_NAME=${SLUG}_app" >> "$GITHUB_ENV"
+          SLUG="$(basename "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+          echo "APP_NAME=${SLUG}" >> "$GITHUB_ENV"
 
       - name: Check if Docker tag exists
         env:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -27,6 +27,7 @@
         "assets": [
           "CHANGELOG.md",
           "scripts/version.txt",
+          "Dockerfile",
           "backend/Dockerfile",
           "frontend/Dockerfile",
           "backend/api/fixtures/version.json",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,73 @@
+###########
+# Stage 1 #
+# Frontend#
+###########
+
+FROM node:lts-alpine AS frontend-builder
+
+WORKDIR /app
+COPY frontend/package*.json ./
+RUN npm install
+COPY frontend/ .
+RUN npm run build
+
+##########
+# Stage 2#
+#  Final  #
+##########
+
+FROM python:3.11.4-slim-bookworm
+
+LABEL maintainer="John Adams"
+LABEL version="1.6.26-rc.1"
+
+# Install system dependencies: nginx, supervisord, db clients, netcat
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    netcat-openbsd \
+    postgresql-client \
+    default-mysql-client \
+    nginx \
+    supervisor \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create app user
+RUN mkdir -p /home/app
+RUN addgroup --system app && adduser --system --group app
+
+# App directories
+ENV HOME=/home/app
+ENV APP_HOME=/home/app/web
+RUN mkdir -p $APP_HOME/staticfiles $APP_HOME/mediafiles $APP_HOME/data
+WORKDIR $APP_HOME
+
+# Copy logos into staticfiles
+COPY backend/logos/favicon.ico $APP_HOME/staticfiles/favicon.ico
+COPY backend/logos/logov2.png $APP_HOME/staticfiles/logov2.png
+
+# Install Python dependencies
+COPY backend/requirements.txt .
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+# Copy built frontend from stage 1
+COPY --from=frontend-builder /app/dist /app/frontend/dist
+
+# Copy nginx config
+COPY nginx/nginx.conf /etc/nginx/sites-available/lenoreshop
+RUN ln -sf /etc/nginx/sites-available/lenoreshop /etc/nginx/sites-enabled/lenoreshop \
+    && rm -f /etc/nginx/sites-enabled/default
+
+# Copy backend source
+COPY backend/ $APP_HOME
+
+# Copy and configure entrypoint
+COPY backend/entrypoint.sh $APP_HOME/entrypoint.sh
+RUN sed -i 's/\r$//g' $APP_HOME/entrypoint.sh \
+    && chmod +x $APP_HOME/entrypoint.sh
+
+# Own app files
+RUN chown -R app:app $APP_HOME
+
+EXPOSE 80
+
+ENTRYPOINT ["/home/app/web/entrypoint.sh"]

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -81,16 +81,26 @@ WSGI_APPLICATION = "backend.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3"),
-        "NAME": os.environ.get("SQL_DATABASE", BASE_DIR / "db.sqlite3"),
-        "USER": os.environ.get("SQL_USER", "user"),
-        "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
-        "HOST": os.environ.get("SQL_HOST", "localhost"),
-        "PORT": os.environ.get("SQL_PORT", "5432"),
+_sql_engine = os.environ.get("SQL_ENGINE", "django.db.backends.sqlite3")
+
+if _sql_engine == "django.db.backends.sqlite3":
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": os.environ.get("SQL_DATABASE", BASE_DIR / "data" / "db.sqlite3"),
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": _sql_engine,
+            "NAME": os.environ.get("SQL_DATABASE", "lenoreshop"),
+            "USER": os.environ.get("SQL_USER", "user"),
+            "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
+            "HOST": os.environ.get("SQL_HOST", "localhost"),
+            "PORT": os.environ.get("SQL_PORT", "5432"),
+        }
+    }
 
 
 # Password validation
@@ -144,14 +154,23 @@ CORS_ORIGIN_WHITELIST = os.environ.get("CSRF_TRUSTED_ORIGINS").split(" ")
 
 ASGI_APPLICATION = "backend.asgi.application"
 
-CHANNEL_LAYERS = {
-    "default": {
-        "BACKEND": "channels_redis.core.RedisChannelLayer",
-        "CONFIG": {
-            "hosts": [("redis://:Outflank-Nickname8-Glorifier@redis:6379/0")],
+REDIS_URL = os.environ.get("REDIS_URL")
+
+if REDIS_URL:
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {
+                "hosts": [REDIS_URL],
+            },
         },
-    },
-}
+    }
+else:
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels.layers.InMemoryChannelLayer",
+        },
+    }
 
 JAZZMIN_SETTINGS = {
     "show_ui_builder": bool(int(os.environ.get("DEBUG"))),

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,14 +1,82 @@
 #!/bin/sh
 
-if [ "$DATABASE" = "postgres" ]
-then
-    echo "Waiting for postgres..."
-
-    while ! nc -z $SQL_HOST $SQL_PORT; do
-      sleep 0.1
-    done
-
-    echo "PostgreSQL started"
+# Wait for external database if configured
+if [ "$SQL_ENGINE" = "django.db.backends.postgresql" ]; then
+    echo "Waiting for PostgreSQL at $SQL_HOST:$SQL_PORT..."
+    while ! nc -z "$SQL_HOST" "$SQL_PORT"; do sleep 0.1; done
+    echo "PostgreSQL is ready."
+elif [ "$SQL_ENGINE" = "django.db.backends.mysql" ]; then
+    echo "Waiting for MySQL at $SQL_HOST:$SQL_PORT..."
+    while ! nc -z "$SQL_HOST" "$SQL_PORT"; do sleep 0.1; done
+    echo "MySQL is ready."
+else
+    echo "Using SQLite — no external database required."
 fi
 
-exec "$@"
+# Django setup
+cd /home/app/web || exit 1
+python manage.py makemigrations --no-input
+python manage.py migrate --no-input
+python manage.py collectstatic --no-input
+python manage.py loaddata version
+
+if [ -n "$DJANGO_SUPERUSER_USERNAME" ]; then
+    python manage.py createsuperuser \
+        --noinput \
+        --username "$DJANGO_SUPERUSER_USERNAME" \
+        --email "$DJANGO_SUPERUSER_EMAIL" || true
+fi
+
+# Build supervisord config
+SUPERVISOR_CONF=/tmp/supervisord.conf
+
+cat > "$SUPERVISOR_CONF" << 'EOF'
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+
+[program:nginx]
+command=nginx -g "daemon off;"
+autostart=true
+autorestart=true
+priority=10
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:daphne]
+command=daphne -b 127.0.0.1 -p 8000 backend.asgi:application
+directory=/home/app/web
+autostart=true
+autorestart=true
+priority=20
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+EOF
+
+# Add Celery worker only if Redis is configured
+if [ -n "$REDIS_URL" ]; then
+    echo "Redis configured — enabling cache and background worker."
+    cat >> "$SUPERVISOR_CONF" << 'EOF'
+
+[program:celery]
+command=celery -A backend worker --loglevel=info
+directory=/home/app/web
+autostart=true
+autorestart=true
+priority=30
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+EOF
+else
+    echo "No REDIS_URL — starting without cache or background worker."
+fi
+
+exec supervisord -c "$SUPERVISOR_CONF"

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: lenoreshop_app:production
+    image: lenoreshop:production
     container_name: lenoreshop_app
     ports:
       - "${APP_PORT:-7000}:80"

--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -1,0 +1,41 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: lenoreshop_app:production
+    container_name: lenoreshop_app
+    ports:
+      - "${APP_PORT:-7000}:80"
+    volumes:
+      - lenoreshop_static:/home/app/web/staticfiles
+      - lenoreshop_media:/home/app/web/mediafiles
+    env_file:
+      - ./.env
+    depends_on:
+      - db
+      - redis
+    restart: unless-stopped
+
+  db:
+    image: postgres:15
+    container_name: lenoreshop_db
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    env_file:
+      - ./.env
+    environment:
+      - POSTGRES_USER=${SQL_USER}
+      - POSTGRES_PASSWORD=${SQL_PASSWORD}
+      - POSTGRES_DB=${SQL_DATABASE}
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: lenoreshop_redis
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  lenoreshop_static:
+  lenoreshop_media:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: lenoreshop_app:production
+    image: lenoreshop:production
     container_name: lenoreshop_app
     ports:
       - "${APP_PORT:-7000}:80"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,70 +1,21 @@
 services:
-  frontend:
-    build: ./frontend
-    networks:
-      - default
-    labels:
-      - "traefik.enable=false"
-    restart: unless-stopped
-    expose:
-      - 80
-    image: lenoreshop_frontend:production
-    container_name: lenoreshop_frontend
-    env_file:
-      - ./.env
-    environment:
-      - NODE_ENV=production
-  backend:
+  app:
     build:
-      context: ./backend
-    command: /home/app/web/start.sh
-    volumes:
-      - static_volume:/home/app/web/staticfiles
-      - media_volume:/home/app/web/mediafiles
-    expose:
-      - 8000
-    depends_on:
-      - db
-    networks:
-      - default
-    labels:
-      - "traefik.enable=false"
-    env_file:
-      - ./.env
-    image: lenoreshop_backend:production
-    container_name: lenoreshop_backend
-    environment:
-      - DEBUG=0
-  db:
-    image: postgres:15
-    volumes:
-      - postgres_data:/var/lib/postgresql/data/
-    env_file:
-      - ./.env
-    networks:
-      - default
-    labels:
-      - "traefik.enable=false"
-    container_name: lenoreshop_db
-    environment:
-      - POSTGRES_USER=${SQL_USER}
-      - POSTGRES_PASSWORD=${SQL_PASSWORD}
-      - POSTGRES_DB=${SQL_DATABASE}
-  nginx:
-    image: novanglus96/lenoreapps_proxy:latest
-    volumes:
-      - static_volume:/home/app/web/staticfiles
-      - media_volume:/home/app/web/mediafiles
-    depends_on:
-      - backend
-      - frontend
-    networks:
-      - default
+      context: .
+      dockerfile: Dockerfile
+    image: lenoreshop_app:production
+    container_name: lenoreshop_app
     ports:
-      - 7000:80
-    container_name: lenoreshop_nginx
+      - "${APP_PORT:-7000}:80"
+    volumes:
+      - lenoreshop_data:/home/app/web/data
+      - lenoreshop_static:/home/app/web/staticfiles
+      - lenoreshop_media:/home/app/web/mediafiles
+    env_file:
+      - ./.env
+    restart: unless-stopped
 
 volumes:
-  postgres_data:
-  static_volume:
-  media_volume:
+  lenoreshop_data:
+  lenoreshop_static:
+  lenoreshop_media:

--- a/example.env
+++ b/example.env
@@ -1,14 +1,25 @@
 DEBUG=0
-SECRET_KEY=mysupersecretkey
-DJANGO_ALLOWED_HOSTS=docker-ip
-CSRF_TRUSTED_ORIGINS=http://docker-ip
-SQL_ENGINE=django.db.backends.postgresql
-SQL_DATABASE=lenoreshop
-SQL_USER=lenoreshopuser
-SQL_PASSWORD=somepassword
-SQL_HOST=db
-SQL_PORT=5432
-DATABASE=postgres
-DJANGO_SUPERUSER_PASSWORD=suepervisorpassword
-DJANGO_SUPERUSER_EMAIL=someone@somewhere.com
-DJANGO_SUPERUSER_USERNAME=supervisor
+SECRET_KEY=changeme-use-a-long-random-string
+DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1
+CSRF_TRUSTED_ORIGINS=http://localhost:7000
+
+# Port the app is exposed on (default: 7000)
+APP_PORT=7000
+
+# Database — leave SQL_ENGINE unset (or set to django.db.backends.sqlite3) to use SQLite
+# For PostgreSQL:
+#   SQL_ENGINE=django.db.backends.postgresql
+#   SQL_DATABASE=lenoreshop
+#   SQL_USER=lenoreshopuser
+#   SQL_PASSWORD=somepassword
+#   SQL_HOST=db
+#   SQL_PORT=5432
+SQL_ENGINE=django.db.backends.sqlite3
+
+# Redis — leave unset to disable caching and background worker
+# REDIS_URL=redis://redis:6379/0
+
+# Superuser created on first run (optional)
+DJANGO_SUPERUSER_PASSWORD=changeme
+DJANGO_SUPERUSER_EMAIL=admin@example.com
+DJANGO_SUPERUSER_USERNAME=admin

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,33 +1,47 @@
 server {
     listen 80;
     server_name localhost;
-    proxy_intercept_errors on;
 
+    # Vue SPA — served from built dist
     location / {
-        proxy_pass http://frontend;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_redirect off;
+        root /app/frontend/dist;
+        try_files $uri $uri/ /index.html;
     }
 
+    # Django REST API
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_redirect off;
     }
 
+    # Django Admin
     location /admin/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://127.0.0.1:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_redirect off;
     }
 
+    # WebSocket (real-time sync)
+    location /ws/ {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Django static files
     location /static/ {
         alias /home/app/web/staticfiles/;
     }
 
+    # Django media files
     location /media/ {
         alias /home/app/web/mediafiles/;
     }

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -9,6 +9,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 VERSION_FILE="scripts/version.txt"
+APP_DOCKER_FILE="Dockerfile"
 BACKEND_DOCKER_FILE="backend/Dockerfile"
 FRONTEND_DOCKER_FILE="frontend/Dockerfile"
 MODEL_VERSION_FILE="backend/api/fixtures/version.json"
@@ -17,6 +18,7 @@ PACKAGE_JSON_FILE="frontend/package.json"
 APP_VUE_FILE="frontend/src/App.vue"
 
 echo "$VERSION" > "$VERSION_FILE"
+sed -i -r "s/^LABEL version=\"[^\"]*\"/LABEL version=\"$VERSION\"/" "$APP_DOCKER_FILE"
 sed -i -r "s/^LABEL version=\"[^\"]*\"/LABEL version=\"$VERSION\"/" "$BACKEND_DOCKER_FILE"
 sed -i -r "s/^LABEL version=\"[^\"]*\"/LABEL version=\"$VERSION\"/" "$FRONTEND_DOCKER_FILE"
 sed -i -r "s/\"version_number\": \"[^\"]*\"/\"version_number\": \"$VERSION\"/" "$MODEL_VERSION_FILE"


### PR DESCRIPTION
## Summary

- Replaces the multi-container prod setup (frontend + backend + nginx + db) with a single self-contained app container
- Multi-stage Dockerfile: Node builds Vue SPA, Python final image runs nginx + daphne via supervisord
- Database and Redis are fully optional — defaults to SQLite + InMemoryChannelLayer with zero external dependencies

## Deployment modes

| Config | Database | Cache / Real-time |
|---|---|---|
| `docker-compose-prod.yml` (default) | SQLite | None |
| `docker-compose-full.yml` | PostgreSQL | Redis + Celery worker |

## Test plan
- [x] Built image locally (`lenoreshop_app:test`)
- [x] Frontend returns 200 (Vue SPA served by nginx)
- [x] API returns data (`/api/version/list` → `{"id":1,"version_number":"1.6.26-rc.1"}`)
- [x] Admin returns 302 (Django login redirect)
- [x] SQLite auto-created, migrations ran, fixture loaded — no external DB needed
- [x] No REDIS_URL → InMemoryChannelLayer, no worker spawned (confirmed in logs)
- [ ] Migration guide (multi-container → single container) — next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)