### PR TITLE
fix: remove deprecated show_defaults option from mkdocs config

### DIFF
--- a/backend/mkdocs.yml
+++ b/backend/mkdocs.yml
@@ -33,7 +33,6 @@ plugins:
             show_root_full_path: false
             show_bases: false
             allow_inspection: true
-            show_defaults: true
             members:
               - __str__
           #rendering:


### PR DESCRIPTION
## Summary

- Removes `show_defaults: true` from `backend/mkdocs.yml` — this option was removed in newer mkdocstrings-python versions
- Default parameter values are now shown automatically in signatures without this flag
- Fixes the Deploy MkDocs (Release) CI failure on v1.6.26-rc.1

## Test plan

- [ ] Verify Deploy MkDocs (Release) workflow succeeds on next release
- [ ] Confirm docs render correctly at the versioned URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)