### PR TITLE
chore: gitignore sandbox compose file and sync script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 mempalace.yaml
 entities.json
 
+# Sandbox — not committed; host-specific
+docker-compose-sandbox.yml
+scripts/sync-live-to-sandbox.sh
+
 *.DS_Store
 static
 media


### PR DESCRIPTION
## Summary

- Adds `docker-compose-sandbox.yml` and `scripts/sync-live-to-sandbox.sh` to `.gitignore`
- These are host-specific developer tools, not application code

🤖 Generated with [Claude Code](https://claude.com/claude-code)