### PR TITLE
fix: compare API version against package.json instead of hardcoded string

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -41,6 +41,7 @@ import { useMainStore } from "@/stores/main";
 import { onMounted, computed, ref, watch, onUnmounted } from "vue";
 import { VueQueryDevtools } from "@tanstack/vue-query-devtools";
 import { useVersion } from "@/composables/versionComposable";
+import { version as appVersion } from "../package.json";
 
 const reloadPage = () => {
   window.location.reload();
@@ -50,7 +51,7 @@ const { prefetchVersion, version } = useVersion();
 const showBanner = ref(false);
 
 const checkVersion = computed(() => {
-  return version.value && version.value.version_number !== "1.6.26-rc.1";
+  return version.value && version.value.version_number !== appVersion;
 });
 
 const updateBanner = () => {


### PR DESCRIPTION
## Summary

- Version mismatch banner was permanently visible because the check was hardcoded to `1.6.26-rc.1`
- Now imports `version` from `package.json` (same as `AppNavigation.vue`) and compares against the API version
- Banner will only show when the backend has been updated to a new version but the browser still has stale cached JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)