### PR TITLE
feat: add MySQL/MariaDB support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netcat-openbsd \
     postgresql-client \
     default-mysql-client \
+    default-libmysqlclient-dev \
+    pkg-config \
     nginx \
     supervisor \
     && rm -rf /var/lib/apt/lists/*

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.db import models
 
 # Create your models here.

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -98,7 +98,7 @@ else:
             "USER": os.environ.get("SQL_USER", "user"),
             "PASSWORD": os.environ.get("SQL_PASSWORD", "password"),
             "HOST": os.environ.get("SQL_HOST", "localhost"),
-            "PORT": os.environ.get("SQL_PORT", "5432"),
+            "PORT": os.environ.get("SQL_PORT", ""),
         }
     }
 

--- a/backend/docs/index.md
+++ b/backend/docs/index.md
@@ -177,6 +177,59 @@ SQL_PORT=5432
 REDIS_URL=redis://redis:6379/0
 ```
 
+**Full setup (MySQL/MariaDB + Redis):**
+
+```yaml
+services:
+  app:
+    image: novanglus96/lenoreshop:latest
+    volumes:
+      - lenoreshop_static:/home/app/web/staticfiles
+      - lenoreshop_media:/home/app/web/mediafiles
+    env_file:
+      - ./.env
+    ports:
+      - "${APP_PORT:-7000}:80"
+    depends_on:
+      - db
+      - redis
+    restart: unless-stopped
+
+  db:
+    image: mysql:8
+    volumes:
+      - mysql_data:/var/lib/mysql
+    env_file:
+      - ./.env
+    environment:
+      - MYSQL_DATABASE=${SQL_DATABASE}
+      - MYSQL_USER=${SQL_USER}
+      - MYSQL_PASSWORD=${SQL_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${SQL_PASSWORD}
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+
+volumes:
+  mysql_data:
+  lenoreshop_static:
+  lenoreshop_media:
+```
+
+For MySQL, add these to your `.env`:
+
+```env
+SQL_ENGINE=django.db.backends.mysql
+SQL_DATABASE=lenoreshop
+SQL_USER=lenoreshopuser
+SQL_PASSWORD=somepassword
+SQL_HOST=db
+SQL_PORT=3306
+REDIS_URL=redis://redis:6379/0
+```
+
 ### Step 3: Run the Application
 
 ```bash

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 Django==4.2.3
 gunicorn==21.2.0
 psycopg2-binary==2.9.6
+mysqlclient==2.2.4
 markdown==3.4.4
 django-filter==23.2
 django-cors-headers==4.2.0

--- a/example.env
+++ b/example.env
@@ -14,6 +14,13 @@ APP_PORT=7000
 #   SQL_PASSWORD=somepassword
 #   SQL_HOST=db
 #   SQL_PORT=5432
+# For MySQL/MariaDB:
+#   SQL_ENGINE=django.db.backends.mysql
+#   SQL_DATABASE=lenoreshop
+#   SQL_USER=lenoreshopuser
+#   SQL_PASSWORD=somepassword
+#   SQL_HOST=db
+#   SQL_PORT=3306
 SQL_ENGINE=django.db.backends.sqlite3
 
 # Redis — leave unset to disable caching and background worker


### PR DESCRIPTION
## Summary

Closes #19

- Adds `mysqlclient==2.2.4` to `requirements.txt`
- Adds `default-libmysqlclient-dev` + `pkg-config` to Dockerfile apt-get (required to compile the mysqlclient C extension)
- Fixes `SQL_PORT` default from hardcoded `5432` to empty string — previously MySQL users who omitted `SQL_PORT` would silently connect to the wrong port
- Adds MySQL/MariaDB compose example and `.env` snippet to Getting Started docs and `example.env`
- Fixes pre-existing `F821` (undefined `ValidationError`) in `backend/api/models.py` caught by ruff

## Test plan

- [ ] Build Docker image: `docker build -t lenoreshop-test .` — confirm `mysqlclient` installs without error
- [ ] Spin up MySQL compose stack with `SQL_ENGINE=django.db.backends.mysql` — confirm migrations run and app starts
- [ ] Confirm SQLite and PostgreSQL paths still work (no regression)
- [ ] Check docs: Getting Started now shows SQLite, PostgreSQL, and MySQL compose examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)