### PR TITLE
feat: drag and drop aisle reordering

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -104,6 +104,15 @@ class AisleOut(Schema):
     store: StoreOut
 
 
+class AisleOrderItem(Schema):
+    id: int
+    order: int
+
+
+class AisleReorderIn(Schema):
+    aisles: List[AisleOrderItem]
+
+
 class ItemIn(Schema):
     """
     Schema to validate an Item.
@@ -747,6 +756,26 @@ def update_aisle(request, aisle_id: int, payload: AisleIn):
     aisle.order = payload.order
     aisle.store_id = payload.store_id
     aisle.save()
+    return {"success": True}
+
+
+@api.put("/aisles/reorder")
+def reorder_aisles(request, payload: AisleReorderIn):
+    """
+    Bulk-update the order of aisles.
+
+    Endpoint:
+        - **Path**: `/api/aisles/reorder`
+        - **Method**: `PUT`
+
+    Args:
+        payload (AisleReorderIn): List of {id, order} pairs.
+
+    Returns:
+        success (bool): True if successfully reordered.
+    """
+    for item in payload.aisles:
+        Aisle.objects.filter(id=item.id).update(order=item.order)
     return {"success": True}
 
 

--- a/frontend/src/components/AisleCard.vue
+++ b/frontend/src/components/AisleCard.vue
@@ -1,7 +1,13 @@
 <template>
   <v-card color="primary" variant="outlined">
-    <v-card-title class="text-h6">
-      ({{ aisle.order }}) {{ aisle.name }}
+    <v-card-title class="text-h6 d-flex align-center">
+      <v-icon
+        v-if="aisle.order !== 0"
+        class="drag-handle mr-2"
+        icon="mdi-drag"
+        style="cursor: grab"
+      />
+      {{ aisle.name }}
     </v-card-title>
     <v-card-subtitle>{{ aisle.store.name }}</v-card-subtitle>
     <v-card-actions>

--- a/frontend/src/composables/aislesComposable.js
+++ b/frontend/src/composables/aislesComposable.js
@@ -69,6 +69,15 @@ async function getAislesByStoreFunction() {
   }
 }
 
+async function reorderAislesFunction(aisles) {
+  try {
+    const response = await apiClient.put('/aisles/reorder', { aisles })
+    return response.data
+  } catch (error) {
+    handleApiError(error, 'Aisles not reordered: ')
+  }
+}
+
 //async function getAislesFunction() {
 //  try {
 //    const response = await apiClient.get('/aisles')
@@ -112,6 +121,13 @@ export function useAisles(storeID) {
     }
   })
 
+  const reorderAislesMutation = useMutation({
+    mutationFn: reorderAislesFunction,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['aisles', storeID] })
+    }
+  })
+
   async function addAisle(newAisle) {
     createAisleMutation.mutate(newAisle);
   }
@@ -124,11 +140,16 @@ export function useAisles(storeID) {
     deleteAisleMutation.mutate(deletedAisle);
   }
 
+  async function reorderAisles(aisles) {
+    reorderAislesMutation.mutate(aisles);
+  }
+
   return {
     aisles,
     isLoading,
     addAisle,
     editAisle,
-    removeAisle
+    removeAisle,
+    reorderAisles,
   }
 }

--- a/frontend/src/views/AisleView.vue
+++ b/frontend/src/views/AisleView.vue
@@ -11,10 +11,25 @@
     <v-container>
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
+          <draggable
+            v-model="sortableAisles"
+            item-key="id"
+            handle=".drag-handle"
+            @end="onReorder"
+          >
+            <template #item="{ element }">
+              <AisleCard
+                :aisle="element"
+                :key="element.id"
+                @edit-aisle="updateAisle"
+                @remove-aisle="deleteAisle"
+              />
+            </template>
+          </draggable>
           <AisleCard
-            v-for="aisle in aisles"
-            :aisle="aisle"
-            :key="aisle.id"
+            v-if="uncategorizedAisle"
+            :aisle="uncategorizedAisle"
+            :key="uncategorizedAisle.id"
             @edit-aisle="updateAisle"
             @remove-aisle="deleteAisle"
           />
@@ -30,7 +45,8 @@
 </template>
 
 <script setup>
-  import { ref } from "vue";
+  import { ref, watch, computed } from "vue";
+  import draggable from "vuedraggable";
   import AisleCard from "@/components/AisleCard.vue";
   import AisleForm from "@/components/AisleForm.vue";
   import { useAisles } from "@/composables/aislesComposable";
@@ -42,9 +58,31 @@
     aisleFormDialog.value = false;
   };
 
-  const { aisles, isLoading, addAisle, editAisle, removeAisle } = useAisles(
-    store.store_id,
+  const { aisles, isLoading, addAisle, editAisle, removeAisle, reorderAisles } =
+    useAisles(store.store_id);
+
+  const sortableAisles = ref([]);
+
+  const uncategorizedAisle = computed(() =>
+    aisles.value?.find(a => a.order === 0) ?? null
   );
+
+  watch(
+    aisles,
+    val => {
+      sortableAisles.value = (val ?? []).filter(a => a.order !== 0);
+    },
+    { immediate: true }
+  );
+
+  const onReorder = () => {
+    const updated = sortableAisles.value.map((aisle, index) => ({
+      id: aisle.id,
+      order: index + 1,
+    }));
+    reorderAisles(updated);
+  };
+
   const createAisle = async newAisle => {
     await addAisle(newAisle);
   };


### PR DESCRIPTION
## Summary

Closes #24

- **Backend**: New `PUT /api/aisles/reorder` endpoint accepts `{ aisles: [{id, order}] }` and bulk-updates order in one request
- **Composable**: `reorderAisles` mutation added to `aislesComposable.js`; invalidates the aisles query on success
- **AisleView**: `v-for` replaced with `<draggable>` (vuedraggable, already installed); "Uncategorized" aisle (order=0) rendered below the drag list and excluded from reordering
- **AisleCard**: `mdi-drag` handle icon added to card title; hidden for Uncategorized; `cursor: grab` style on the handle

**Behaviour**: dragging a card to a new position reassigns all orders as 1-based sequential values matching the new visual order, then persists to the API.

## Test plan

- [ ] Open Aisles page for a store with multiple aisles
- [ ] Drag handle (≡) is visible on each aisle card except Uncategorized
- [ ] Drag an aisle to a new position — order persists after page refresh
- [ ] Uncategorized aisle always appears at the bottom and cannot be dragged
- [ ] Add/edit/delete aisle still works alongside drag and drop
- [ ] No regression on shopping list view (aisles still render in saved order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)