### PR TITLE
fix: move reorder endpoint before parameterized aisle route

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -734,6 +734,26 @@ def list_listsbystore(request, store_id: int):
     return qs
 
 
+@api.put("/aisles/reorder")
+def reorder_aisles(request, payload: AisleReorderIn):
+    """
+    Bulk-update the order of aisles.
+
+    Endpoint:
+        - **Path**: `/api/aisles/reorder`
+        - **Method**: `PUT`
+
+    Args:
+        payload (AisleReorderIn): List of {id, order} pairs.
+
+    Returns:
+        success (bool): True if successfully reordered.
+    """
+    for item in payload.aisles:
+        Aisle.objects.filter(id=item.id).update(order=item.order)
+    return {"success": True}
+
+
 @api.put("/aisles/{aisle_id}")
 def update_aisle(request, aisle_id: int, payload: AisleIn):
     """
@@ -756,26 +776,6 @@ def update_aisle(request, aisle_id: int, payload: AisleIn):
     aisle.order = payload.order
     aisle.store_id = payload.store_id
     aisle.save()
-    return {"success": True}
-
-
-@api.put("/aisles/reorder")
-def reorder_aisles(request, payload: AisleReorderIn):
-    """
-    Bulk-update the order of aisles.
-
-    Endpoint:
-        - **Path**: `/api/aisles/reorder`
-        - **Method**: `PUT`
-
-    Args:
-        payload (AisleReorderIn): List of {id, order} pairs.
-
-    Returns:
-        success (bool): True if successfully reordered.
-    """
-    for item in payload.aisles:
-        Aisle.objects.filter(id=item.id).update(order=item.order)
     return {"success": True}
 
 


### PR DESCRIPTION
## Summary

Fixes 422 error when dragging aisles to reorder them.

`PUT /aisles/reorder` was registered after `PUT /aisles/{aisle_id}`. Django-Ninja matched the literal string `"reorder"` against the `{aisle_id}` integer parameter, failed type coercion, and returned 422. Moving the static route above the parameterized one fixes the routing.

## Test plan

- [ ] Drag an aisle — no 422, order persists after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)