### PR TITLE
fix: change aisle reorder endpoint from PUT to POST

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -734,7 +734,7 @@ def list_listsbystore(request, store_id: int):
     return qs
 
 
-@api.put("/aisles/reorder")
+@api.post("/aisles/reorder")
 def reorder_aisles(request, payload: AisleReorderIn):
     """
     Bulk-update the order of aisles.

--- a/frontend/src/composables/aislesComposable.js
+++ b/frontend/src/composables/aislesComposable.js
@@ -71,7 +71,7 @@ async function getAislesByStoreFunction() {
 
 async function reorderAislesFunction(aisles) {
   try {
-    const response = await apiClient.put('/aisles/reorder', { aisles })
+    const response = await apiClient.post('/aisles/reorder', { aisles })
     return response.data
   } catch (error) {
     handleApiError(error, 'Aisles not reordered: ')


### PR DESCRIPTION
## Summary

Fixes the persistent 422 error when dragging aisles to reorder.

**Root cause**: django-ninja 0.22 generates URL patterns without typed converters — `{aisle_id}` matches *any* string, not just integers. So `PUT /aisles/reorder` always resolved to `PUT /aisles/{aisle_id}`, which tried to coerce `"reorder"` to an int and returned 422. Registration order had no effect.

**Fix**: Change the reorder endpoint from `PUT` to `POST`. No `POST /aisles/{aisle_id}` route exists, so there is no conflict.

**Evidence from 422 response body:**
```json
{"detail": [{"loc": ["path", "aisle_id"], "msg": "value is not a valid integer"}, ...]}
```

## Changes
- `backend/backend/api.py`: `@api.put("/aisles/reorder")` → `@api.post("/aisles/reorder")`
- `frontend/src/composables/aislesComposable.js`: `apiClient.put(...)` → `apiClient.post(...)`

## Test plan
- [ ] Drag an aisle — no 422, order persists after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)