### PR TITLE
fix: reorder aisles using individual PUT calls instead of bulk endpoint

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -104,15 +104,6 @@ class AisleOut(Schema):
     store: StoreOut
 
 
-class AisleOrderItem(Schema):
-    id: int
-    order: int
-
-
-class AisleReorderIn(Schema):
-    aisles: List[AisleOrderItem]
-
-
 class ItemIn(Schema):
     """
     Schema to validate an Item.
@@ -732,26 +723,6 @@ def list_listsbystore(request, store_id: int):
     """
     qs = ShoppingList.objects.all().filter(store__id=store_id)
     return qs
-
-
-@api.post("/aisles/reorder")
-def reorder_aisles(request, payload: AisleReorderIn):
-    """
-    Bulk-update the order of aisles.
-
-    Endpoint:
-        - **Path**: `/api/aisles/reorder`
-        - **Method**: `PUT`
-
-    Args:
-        payload (AisleReorderIn): List of {id, order} pairs.
-
-    Returns:
-        success (bool): True if successfully reordered.
-    """
-    for item in payload.aisles:
-        Aisle.objects.filter(id=item.id).update(order=item.order)
-    return {"success": True}
 
 
 @api.put("/aisles/{aisle_id}")

--- a/frontend/src/composables/aislesComposable.js
+++ b/frontend/src/composables/aislesComposable.js
@@ -71,8 +71,11 @@ async function getAislesByStoreFunction() {
 
 async function reorderAislesFunction(aisles) {
   try {
-    const response = await apiClient.post('/aisles/reorder', { aisles })
-    return response.data
+    await Promise.all(
+      aisles.map(({ id, order, name, store_id }) =>
+        apiClient.put('/aisles/' + id, { name, order, store_id })
+      )
+    )
   } catch (error) {
     handleApiError(error, 'Aisles not reordered: ')
   }

--- a/frontend/src/views/AisleView.vue
+++ b/frontend/src/views/AisleView.vue
@@ -77,7 +77,7 @@
 
   const onReorder = () => {
     const updated = sortableAisles.value.map((aisle, index) => ({
-      id: aisle.id,
+      ...aisle,
       order: index + 1,
     }));
     reorderAisles(updated);


### PR DESCRIPTION
## Summary

Closes the drag-and-drop 422/405 error chain.

The `/aisles/reorder` endpoint couldn't coexist with `/aisles/{aisle_id}` in django-ninja 0.22 regardless of HTTP method or registration order — ninja doesn't use typed URL converters so the parameterized route always won.

**Fix**: remove the bulk endpoint entirely. The existing `PUT /aisles/{aisle_id}` already updates the `order` field. On drag-end, the composable fires one PUT per aisle in parallel via `Promise.all`. For a typical store with 5–10 aisles this is negligible.

## Changes
- `backend/backend/api.py`: remove `AisleOrderItem`, `AisleReorderIn` schemas and `POST /aisles/reorder` endpoint
- `frontend/src/composables/aislesComposable.js`: `reorderAislesFunction` now calls `PUT /aisles/{id}` for each aisle via `Promise.all`
- `frontend/src/views/AisleView.vue`: `onReorder` spreads full aisle object (not just `{id, order}`) so `name` and `store_id` are available for the PUT payload

## Test plan
- [ ] Drag an aisle — no error, order persists after refresh
- [ ] Edit/delete aisle still works (uses same PUT endpoint, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)