### PR TITLE
feat: add offline mode with optimistic updates and pending sync queue

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -32,6 +32,15 @@
           >
         </template>
       </v-snackbar>
+      <v-snackbar
+        v-model="showOfflineBanner"
+        color="warning"
+        location="top"
+        timeout="-1"
+      >
+        <v-icon icon="mdi-wifi-off" class="mr-2" />
+        You're offline. Changes will sync when connection is restored.
+      </v-snackbar>
     </v-main>
   </v-app>
 </template>
@@ -41,6 +50,7 @@ import { useMainStore } from "@/stores/main";
 import { onMounted, computed, ref, watch, onUnmounted } from "vue";
 import { VueQueryDevtools } from "@tanstack/vue-query-devtools";
 import { useVersion } from "@/composables/versionComposable";
+import { useOffline } from "@/composables/offlineComposable";
 import { version as appVersion } from "../package.json";
 
 const reloadPage = () => {
@@ -48,7 +58,9 @@ const reloadPage = () => {
 };
 const store = useMainStore();
 const { prefetchVersion, version } = useVersion();
+const { isOffline } = useOffline();
 const showBanner = ref(false);
+const showOfflineBanner = computed(() => isOffline.value);
 
 const checkVersion = computed(() => {
   return version.value && version.value.version_number !== appVersion;

--- a/frontend/src/composables/listsComposable.js
+++ b/frontend/src/composables/listsComposable.js
@@ -1,6 +1,13 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/vue-query";
+import { watch } from "vue";
 import axios from "axios";
 import { useMainStore } from "@/stores/main";
+import {
+  isOffline,
+  savePendingUpdate,
+  removePendingUpdate,
+  loadPendingUpdates,
+} from "@/composables/offlineComposable";
 
 const apiClient = axios.create({
   baseURL: "/api",
@@ -217,6 +224,59 @@ export function useShoppingLists() {
   };
 }
 
+// Move item between aisles/purchased_aisles in the cached full list
+function applyOptimisticPurchase(old, updatedListItem) {
+  if (!old) return old;
+  const { id, purchased } = updatedListItem;
+
+  const removeFromAisles = (aisles) => {
+    let removedItem = null;
+    let sourceAisle = null;
+    const updated = aisles.map((aisle) => {
+      const idx = aisle.listitems.findIndex((i) => i.id === id);
+      if (idx !== -1) {
+        removedItem = { ...aisle.listitems[idx], purchased };
+        sourceAisle = aisle;
+        return { ...aisle, listitems: aisle.listitems.filter((i) => i.id !== id) };
+      }
+      return aisle;
+    });
+    return { updated, removedItem, sourceAisle };
+  };
+
+  const addToAisles = (aisles, item, sourceAisle) => {
+    const existing = aisles.find((a) => a.id === sourceAisle.id);
+    if (existing) {
+      return aisles.map((a) =>
+        a.id === sourceAisle.id
+          ? { ...a, listitems: [...a.listitems, item] }
+          : a,
+      );
+    }
+    return [...aisles, { ...sourceAisle, listitems: [item] }];
+  };
+
+  if (purchased) {
+    const { updated: newAisles, removedItem, sourceAisle } = removeFromAisles(old.aisles);
+    if (!removedItem) return old;
+    return {
+      ...old,
+      aisles: newAisles,
+      purchased_aisles: addToAisles(old.purchased_aisles, removedItem, sourceAisle),
+      totalpurchased: old.totalpurchased + 1,
+    };
+  } else {
+    const { updated: newPurchasedAisles, removedItem, sourceAisle } = removeFromAisles(old.purchased_aisles);
+    if (!removedItem) return old;
+    return {
+      ...old,
+      aisles: addToAisles(old.aisles, removedItem, sourceAisle),
+      purchased_aisles: newPurchasedAisles,
+      totalpurchased: Math.max(0, old.totalpurchased - 1),
+    };
+  }
+}
+
 export function useFullShoppingList(listID) {
   const queryClient = useQueryClient();
 
@@ -245,8 +305,27 @@ export function useFullShoppingList(listID) {
 
   const updateListItemMutation = useMutation({
     mutationFn: updateListItemFunction,
-    onSuccess: () => {
-      console.log("Success updating list item");
+    onMutate: async (updatedListItem) => {
+      await queryClient.cancelQueries({ queryKey: ["fullshoppinglist", listID] });
+      const previousList = queryClient.getQueryData(["fullshoppinglist", listID]);
+      queryClient.setQueryData(["fullshoppinglist", listID], (old) =>
+        applyOptimisticPurchase(old, updatedListItem),
+      );
+      return { previousList };
+    },
+    onError: (err, updatedListItem, context) => {
+      if (!navigator.onLine) {
+        // Keep the optimistic state, queue for sync when back online
+        savePendingUpdate(updatedListItem);
+        return;
+      }
+      if (context?.previousList) {
+        queryClient.setQueryData(["fullshoppinglist", listID], context.previousList);
+      }
+      console.error("Error updating list item");
+    },
+    onSuccess: (data, updatedListItem) => {
+      removePendingUpdate(updatedListItem.id);
       queryClient.invalidateQueries({ queryKey: ["fullshoppinglist", listID] });
     },
   });
@@ -265,6 +344,23 @@ export function useFullShoppingList(listID) {
       console.log("Success clearing purchased list");
       queryClient.invalidateQueries({ queryKey: ["fullshoppinglist", listID] });
     },
+  });
+
+  // Flush pending updates when connection is restored
+  watch(isOffline, async (offline) => {
+    if (offline) return;
+    const pending = loadPendingUpdates();
+    for (const item of pending) {
+      try {
+        await updateListItemFunction(item);
+        removePendingUpdate(item.id);
+      } catch {
+        // Will retry on next reconnect
+      }
+    }
+    if (pending.length > 0) {
+      queryClient.invalidateQueries({ queryKey: ["fullshoppinglist", listID] });
+    }
   });
 
   async function addListItem(listItem) {

--- a/frontend/src/composables/offlineComposable.js
+++ b/frontend/src/composables/offlineComposable.js
@@ -1,0 +1,45 @@
+import { ref } from "vue";
+
+export const isOffline = ref(!navigator.onLine);
+
+window.addEventListener("online", () => {
+  isOffline.value = false;
+});
+window.addEventListener("offline", () => {
+  isOffline.value = true;
+});
+
+const STORAGE_KEY = "pendingListItemUpdates";
+
+export function loadPendingUpdates() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function savePendingUpdate(listItem) {
+  const pending = loadPendingUpdates();
+  const idx = pending.findIndex((p) => p.id === listItem.id);
+  if (idx !== -1) {
+    pending[idx] = listItem;
+  } else {
+    pending.push(listItem);
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+}
+
+export function removePendingUpdate(id) {
+  const pending = loadPendingUpdates().filter((p) => p.id !== id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(pending));
+}
+
+export function clearPendingUpdates() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function useOffline() {
+  return { isOffline };
+}

--- a/frontend/src/views/ListView.vue
+++ b/frontend/src/views/ListView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="lists">
-    <v-btn density="compact" @click="listItemFormDialog = true">Add Item</v-btn>
+    <v-btn density="compact" @click="listItemFormDialog = true" :disabled="isOffline">Add Item</v-btn>
     <ListItemForm
       v-model="listItemFormDialog"
       @add-list-item="createListItem"
@@ -31,6 +31,7 @@
                 variant="outlined"
                 prepend-icon="mdi-delete-sweep-outline"
                 v-bind="activatorProps"
+                :disabled="isOffline"
               >
                 Clear Purchased
               </v-btn>
@@ -56,6 +57,7 @@
                 variant="outlined"
                 prepend-icon="mdi-delete-sweep-outline"
                 v-bind="activatorProps"
+                :disabled="isOffline"
               >
                 Clear All
               </v-btn>
@@ -128,8 +130,10 @@
   import ListItemForm from "@/components/ListItemForm.vue";
   import { useFullShoppingList } from "@/composables/listsComposable";
   import { useMainStore } from "@/stores/main";
+  import { useOffline } from "@/composables/offlineComposable";
 
   const store = useMainStore();
+  const { isOffline } = useOffline();
   const clear_full_dialog = ref(false);
   const clear_purchased_dialog = ref(false);
   const listItemFormDialog = ref(false);


### PR DESCRIPTION
## Summary
- Adds `offlineComposable.js` — module-level reactive `isOffline` ref driven by `window` online/offline events
- Optimistic UI updates for marking items purchased: item moves between sections immediately without waiting for the server
- Pending sync queue persisted in `localStorage`: if a purchase write fails while offline, the update is held and flushed automatically when connection is restored
- Offline banner in `App.vue` (top-of-screen warning snackbar with wifi-off icon)
- Add Item / Clear All / Clear Purchased buttons in `ListView.vue` disabled while offline

## Note
Re-targeting to `rc` — PR #38 was accidentally merged to `main` directly.

## Test plan
- [ ] Go offline (DevTools → Network → Offline) and open the shopping list — list loads from service worker cache
- [ ] Check off a few items while offline — items move to Purchased section immediately, no error shown
- [ ] Confirm Add Item / Clear buttons are disabled
- [ ] Go back online — pending updates flush and list resyncs with server
- [ ] Confirm offline banner appears/disappears correctly with network toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)