### PR TITLE
feat: consolidate nav menu, move version to footer, edge-to-edge mobile layout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,7 @@
     <VueQueryDevtools />
     <AppNavigation />
     <v-main>
-      <v-container fluid-class="pa-2">
+      <v-container fluid class="pa-0">
         <router-view />
       </v-container>
       <v-snackbar

--- a/frontend/src/components/AppNavigation.vue
+++ b/frontend/src/components/AppNavigation.vue
@@ -11,30 +11,20 @@
           </template>
           <v-list-item-title>{{ menu.title }}</v-list-item-title>
         </v-list-item>
-      </v-list>
-    </v-menu>
-    <v-img :width="201" aspect-ratio="1/1" src="logov2.png" inline></v-img>
-    <span class="text-subtitle-2 font-italic text-grey-darken-1">v{{ version }}</span>
-    <v-spacer></v-spacer>
-    <v-menu v-model="menu" :close-on-content-click="false" location="end">
-      <template v-slot:activator="{ props }">
-        <v-btn icon="mdi-dots-vertical" v-bind="props"></v-btn>
-      </template>
-
-      <v-list>
         <v-list-item as="a" href="/admin" prepend-icon="mdi-security">
           <v-list-item-title>Admin</v-list-item-title>
         </v-list-item>
-        <!--<v-list-item to="/logout" prepend-icon="mdi-logout">
-          <v-list-item-title>Logout</v-list-item-title>
-        </v-list-item>-->
+        <v-divider />
+        <v-list-item disabled>
+          <v-list-item-title class="text-caption text-grey">v{{ version }}</v-list-item-title>
+        </v-list-item>
       </v-list>
     </v-menu>
+    <v-img :width="201" aspect-ratio="1/1" src="logov2.png" inline></v-img>
   </v-app-bar>
 </template>
 
 <script setup>
-  import { ref } from "vue";
   import { version } from "../../package.json";
 
   const menus = [
@@ -43,8 +33,6 @@
     { title: "Shopping Lists", url: "/lists", icon: "mdi-cart-outline" },
     { title: "Items", url: "/items", icon: "mdi-food-apple-outline" },
   ];
-
-  const menu = ref(false);
 </script>
 
 <style scoped></style>

--- a/frontend/src/views/AisleView.vue
+++ b/frontend/src/views/AisleView.vue
@@ -8,7 +8,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container>
+    <v-container fluid class="pa-0 pa-sm-2">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <draggable

--- a/frontend/src/views/ItemView.vue
+++ b/frontend/src/views/ItemView.vue
@@ -9,7 +9,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container>
+    <v-container fluid class="pa-0 pa-sm-2">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <ItemCard

--- a/frontend/src/views/ListView.vue
+++ b/frontend/src/views/ListView.vue
@@ -9,7 +9,7 @@
       :isEdit="false"
       :key="-1"
     />
-    <v-container>
+    <v-container fluid class="pa-0 pa-sm-2">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <h2 class="text-h6 text-primary ps-4">{{ fullshoppinglist.name }}</h2>

--- a/frontend/src/views/ListsView.vue
+++ b/frontend/src/views/ListsView.vue
@@ -8,7 +8,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container>
+    <v-container fluid class="pa-0 pa-sm-2">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <ListCard

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -9,7 +9,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container>
+    <v-container fluid class="pa-0 pa-sm-2">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <StoreCard


### PR DESCRIPTION
## Summary
- Removed top-right dots menu; Admin link moved into the hamburger menu below nav items
- Version string moved from the app bar to the bottom of the hamburger menu (divider + disabled caption item)
- Fixed outer `v-container` in `App.vue` (`fluid-class` was a no-op prop — replaced with `fluid class="pa-0"`)
- All view inner containers changed to `fluid class="pa-0 pa-sm-2"` — cards/lists go edge-to-edge on mobile, small padding restored on sm+ screens

## Test plan
- [ ] Hamburger menu shows Home, Stores, Shopping Lists, Items, Admin, divider, version
- [ ] No dots menu in top-right corner
- [ ] On mobile: cards and lists extend to screen edges
- [ ] On tablet/desktop: normal padding is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)