### PR TITLE
fix: improve spacing — top gap on mobile, more margin on desktop

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,7 @@
     <VueQueryDevtools />
     <AppNavigation />
     <v-main>
-      <v-container fluid class="pa-0">
+      <v-container fluid class="pa-0 pt-3 pa-sm-4">
         <router-view />
       </v-container>
       <v-snackbar

--- a/frontend/src/components/AppNavigation.vue
+++ b/frontend/src/components/AppNavigation.vue
@@ -15,8 +15,8 @@
           <v-list-item-title>Admin</v-list-item-title>
         </v-list-item>
         <v-divider />
-        <v-list-item disabled>
-          <v-list-item-title class="text-caption text-grey">v{{ version }}</v-list-item-title>
+        <v-list-item disabled class="justify-center">
+          <v-list-item-title class="text-caption text-grey text-center">v{{ version }}</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>

--- a/frontend/src/views/AisleView.vue
+++ b/frontend/src/views/AisleView.vue
@@ -8,7 +8,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <draggable

--- a/frontend/src/views/ItemView.vue
+++ b/frontend/src/views/ItemView.vue
@@ -9,7 +9,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <ItemCard

--- a/frontend/src/views/ListView.vue
+++ b/frontend/src/views/ListView.vue
@@ -9,7 +9,7 @@
       :isEdit="false"
       :key="-1"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <h2 class="text-h6 text-primary ps-4">{{ fullshoppinglist.name }}</h2>

--- a/frontend/src/views/ListsView.vue
+++ b/frontend/src/views/ListsView.vue
@@ -8,7 +8,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <ListCard

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -9,7 +9,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <StoreCard


### PR DESCRIPTION
## Summary
- App.vue outer container: `pa-0 pt-3 pa-sm-4` — 12px top gap on mobile (breathing room below nav bar), 16px all-around on sm and above
- Inner view containers simplified to `fluid class="pa-0"` — spacing is now controlled at one place (the outer wrapper) instead of duplicated at every view level

## Test plan
- [ ] Mobile: visible gap between nav bar and first card/list
- [ ] Mobile: cards still extend to screen edges (no left/right padding)
- [ ] Tablet/desktop: comfortable 16px margin on all sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)