### PR TITLE
fix: ui spacing, admin link, and version endpoint

### DIFF
--- a/backend/backend/api.py
+++ b/backend/backend/api.py
@@ -1,5 +1,5 @@
 from ninja import NinjaAPI, Schema, Query
-from api.models import Store, Aisle, Item, ListItem, ShoppingList, Version
+from api.models import Store, Aisle, Item, ListItem, ShoppingList
 from typing import List, Optional
 from django.shortcuts import get_object_or_404
 from ninja.errors import HttpError
@@ -19,11 +19,9 @@ class VersionOut(Schema):
     Schema to represent a Version.
 
     Attributes:
-        id (int): ID integer. Unique.
         version_number (str): The version of the app.
     """
 
-    id: int
     version_number: str
 
 
@@ -1073,11 +1071,7 @@ def list_version(request):
         (VersionOut): a version object
     """
 
-    try:
-        qs = get_object_or_404(Version, id=1)
-        return qs
-    except Exception as e:
-        raise HttpError(500, f"Record retrieval error: {str(e)}")
+    return {"version_number": api.version}
 
 
 @api.post("/demo/load", response={200: dict, 409: dict})

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,7 +3,7 @@
     <VueQueryDevtools />
     <AppNavigation />
     <v-main>
-      <v-container fluid class="pa-0">
+      <v-container fluid class="pa-0 pt-3 pa-sm-4">
         <router-view />
       </v-container>
       <v-snackbar

--- a/frontend/src/components/AppNavigation.vue
+++ b/frontend/src/components/AppNavigation.vue
@@ -11,7 +11,7 @@
           </template>
           <v-list-item-title>{{ menu.title }}</v-list-item-title>
         </v-list-item>
-        <v-list-item as="a" href="/admin" prepend-icon="mdi-security">
+        <v-list-item as="a" href="/admin/" prepend-icon="mdi-security">
           <v-list-item-title>Admin</v-list-item-title>
         </v-list-item>
         <v-divider />

--- a/frontend/src/components/AppNavigation.vue
+++ b/frontend/src/components/AppNavigation.vue
@@ -15,8 +15,8 @@
           <v-list-item-title>Admin</v-list-item-title>
         </v-list-item>
         <v-divider />
-        <v-list-item disabled>
-          <v-list-item-title class="text-caption text-grey">v{{ version }}</v-list-item-title>
+        <v-list-item disabled class="justify-center">
+          <v-list-item-title class="text-caption text-grey text-center">v{{ version }}</v-list-item-title>
         </v-list-item>
       </v-list>
     </v-menu>

--- a/frontend/src/views/AisleView.vue
+++ b/frontend/src/views/AisleView.vue
@@ -8,7 +8,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <draggable

--- a/frontend/src/views/ItemView.vue
+++ b/frontend/src/views/ItemView.vue
@@ -9,7 +9,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <ItemCard

--- a/frontend/src/views/ListView.vue
+++ b/frontend/src/views/ListView.vue
@@ -9,7 +9,7 @@
       :isEdit="false"
       :key="-1"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <h2 class="text-h6 text-primary ps-4">{{ fullshoppinglist.name }}</h2>

--- a/frontend/src/views/ListsView.vue
+++ b/frontend/src/views/ListsView.vue
@@ -8,7 +8,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <ListCard

--- a/frontend/src/views/StoreView.vue
+++ b/frontend/src/views/StoreView.vue
@@ -9,7 +9,7 @@
       @update-dialog="updateDialog"
       :passedFormData="blankFormData"
     />
-    <v-container fluid class="pa-0 pa-sm-2">
+    <v-container fluid class="pa-0">
       <v-row dense v-if="!isLoading">
         <v-col cols="12">
           <StoreCard


### PR DESCRIPTION
## Summary
- App.vue outer container: `pa-0 pt-3 pa-sm-4` — 12px top gap on mobile, 16px all-around on sm+
- Inner view containers simplified to `fluid class="pa-0"` — spacing owned by one place
- Version text in nav menu footer centered
- Admin link: `href="/admin"` → `href="/admin/"` (trailing slash required for Nginx location match)
- Version endpoint now returns `api.version` directly instead of querying the database — fixes version mismatch on PostgreSQL deployments where `loaddata` doesn't reliably update the live record
- Dropped unused `Version` model import and `id` field from `VersionOut` schema

## Test plan
- [ ] Mobile: visible gap below nav bar, cards edge-to-edge
- [ ] Desktop: 16px margin all sides
- [ ] Hamburger menu: version centered at bottom
- [ ] Admin link navigates to Django admin page
- [ ] Version banner does not appear on fresh deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)