### PR TITLE
fix: use window.location.assign for admin link to bypass Vue Router

### DIFF
--- a/frontend/src/components/AppNavigation.vue
+++ b/frontend/src/components/AppNavigation.vue
@@ -11,7 +11,7 @@
           </template>
           <v-list-item-title>{{ menu.title }}</v-list-item-title>
         </v-list-item>
-        <v-list-item as="a" href="/admin/" prepend-icon="mdi-security">
+        <v-list-item prepend-icon="mdi-security" @click="() => window.location.assign('/admin/')">
           <v-list-item-title>Admin</v-list-item-title>
         </v-list-item>
         <v-divider />


### PR DESCRIPTION
## Summary
Vue Router with `createWebHistory` intercepts all same-origin `<a>` tag clicks regardless of whether they use `href` or `as="a"`. Clicking the admin link was being caught by the `/:catchAll(.*)` route and redirected to `/` by the `beforeEach` guard.

Replaced `as="a" href="/admin/"` with a click handler using `window.location.assign('/admin/')`, which forces a real full-page browser navigation that Vue Router cannot intercept.

## Test plan
- [ ] Clicking Admin in the hamburger menu navigates to the Django admin page

🤖 Generated with [Claude Code](https://claude.com/claude-code)