### PR TITLE
fix: exclude /admin from service worker navigateFallback

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -50,6 +50,7 @@ export default defineConfig({
         ],
       },
       workbox: {
+        navigateFallbackDenylist: [/^\/admin/],
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
         runtimeCaching: [
           {


### PR DESCRIPTION
## Root Cause
The Workbox service worker has no `navigateFallbackDenylist`, so it intercepts navigation requests to `/admin/` and serves the SPA's `index.html` before the request ever reaches Nginx or Django. `window.location.assign` and plain `<a href>` both lose to the service worker because it operates at the network layer, below JavaScript.

## Fix
Added `navigateFallbackDenylist: [/^\/admin/]` to the workbox config. The regex matches both `/admin` and `/admin/` (and any sub-path like `/admin/login/`), allowing those requests to pass through to Nginx/Django uninterrupted.

## Test plan
- [ ] Clicking Admin in the hamburger menu navigates to the Django admin page
- [ ] `/admin/` (direct URL) reaches Django admin
- [ ] Offline mode and API caching are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)