### PR TITLE
fix: revert admin link to plain anchor now that SW denylist is in place

### DIFF
--- a/frontend/src/components/AppNavigation.vue
+++ b/frontend/src/components/AppNavigation.vue
@@ -11,7 +11,7 @@
           </template>
           <v-list-item-title>{{ menu.title }}</v-list-item-title>
         </v-list-item>
-        <v-list-item prepend-icon="mdi-security" @click="() => window.location.assign('/admin/')">
+        <v-list-item as="a" href="/admin/" prepend-icon="mdi-security">
           <v-list-item-title>Admin</v-list-item-title>
         </v-list-item>
         <v-divider />


### PR DESCRIPTION
## Summary
`window.location.assign` in a Vuetify `v-list-item` click handler has event sequencing issues — the menu close event interferes with the navigation. The simple `as="a" href="/admin/"` anchor is the correct approach and works now that the service worker's `navigateFallbackDenylist` (PR #44) is in place to let `/admin/` pass through to Nginx/Django.

This mirrors the fix confirmed working in LenoreChore.

## Test plan
- [ ] Clicking Admin in the hamburger menu navigates to the Django admin page

🤖 Generated with [Claude Code](https://claude.com/claude-code)