### PR TITLE
fix: remove redundant logo from HomeView

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="home">
-    <img alt="LenoreShop logo" src="/logov2.png" />
     <HelloWorld />
   </div>
 </template>


### PR DESCRIPTION
## Summary
Logo is already displayed in the app bar — the duplicate `<img>` on the home page is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)