### PR TITLE
docs: clarify migration guide title and update roadmap for v1.7.0/v2.0.0

### DIFF
--- a/backend/docs/index.md
+++ b/backend/docs/index.md
@@ -80,7 +80,7 @@ Welcome to LenoreShop! This guide will help you set up and run the application u
 * [Docker](https://www.docker.com/get-started)
 * [Docker Compose](https://docs.docker.com/compose/install/)
 
-> **Upgrading from v1?** See the [Migration Guide](migration-v1-to-v2.md).
+> **Upgrading from a pre-1.7.0 multi-container install?** See the [Migration Guide](migration-v1-to-v2.md).
 
 <!-- INSTALLATION -->
 ### Step 1: Create a `.env` File
@@ -253,11 +253,17 @@ Enjoy using LenoreShop!
 <!-- ROADMAP -->
 ## Roadmap
 
-- [ ] v2.0 Release
-    - [ ] Improved UI
-    - [ ] Offline Mode
-- [ ] Google/Alexa assistant integration
-- [ ] Import from other sources
+**v1.7.0** ✅ Released
+- Single-container deployment
+- MySQL/MariaDB support
+- Demo data loader
+- Drag-and-drop aisle reordering
+- Offline mode (PWA)
+- UI refresh
+
+**v2.0.0** — Planned
+- [ ] Wishlists
+- [ ] Packing lists
 
 See the [open issues](https://github.com/Novanglus96/LenoreShop/issues) for a full list of proposed features (and known issues).
 

--- a/backend/docs/migration-v1-to-v2.md
+++ b/backend/docs/migration-v1-to-v2.md
@@ -1,6 +1,6 @@
-# Migrating from v1 to v2 (Single Container)
+# Migrating to v1.7.0 (Single Container)
 
-Starting with **v1.7.0**, LenoreShop ships as a single self-contained Docker image instead of four separate containers (frontend, backend, nginx, db). This guide walks through migrating an existing v1 installation to the new architecture.
+Starting with **v1.7.0**, LenoreShop ships as a single self-contained Docker image instead of four separate containers (frontend, backend, nginx, db). This guide walks through migrating an existing pre-1.7.0 installation to the new architecture.
 
 ---
 

--- a/backend/mkdocs.yml
+++ b/backend/mkdocs.yml
@@ -4,7 +4,7 @@ site_author: John Adams
 copyright: 2025 John Adams
 nav:
   - Home: index.md
-  - Migration Guide: migration-v1-to-v2.md
+  - Migrating to v1.7.0: migration-v1-to-v2.md
   - Reference:
       - Models: models.md
       - API: api.md


### PR DESCRIPTION
## Summary
The migration guide already existed (`migration-v1-to-v2.md`) but had a confusing title since we shipped 1.7.0, not 2.0. Updates:

- Migration guide title: "Migrating from v1 to v2" → "Migrating to v1.7.0 (Single Container)"
- `index.md` upgrade callout updated to reference "pre-1.7.0 multi-container install"
- MkDocs nav label updated to "Migrating to v1.7.0"
- Roadmap section rewritten: marks v1.7.0 features as released ✅, lists v2.0.0 planned features (Wishlists, Packing Lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)