### PR TITLE
docs: fix migration guide link path in README symlink context

### DIFF
--- a/backend/docs/index.md
+++ b/backend/docs/index.md
@@ -80,7 +80,7 @@ Welcome to LenoreShop! This guide will help you set up and run the application u
 * [Docker](https://www.docker.com/get-started)
 * [Docker Compose](https://docs.docker.com/compose/install/)
 
-> **Upgrading from a pre-1.7.0 multi-container install?** See the [Migration Guide](migration-v1-to-v2.md).
+> **Upgrading from a pre-1.7.0 multi-container install?** See the [Migration Guide](backend/docs/migration-v1-to-v2.md).
 
 <!-- INSTALLATION -->
 ### Step 1: Create a `.env` File


### PR DESCRIPTION
## Root Cause
`README.md` is a symlink to `backend/docs/index.md`. GitHub resolves relative links from where the file *appears* to be (the repo root), so `migration-v1-to-v2.md` looked for a file at the root — which doesn't exist.

## Fix
Changed the link from `migration-v1-to-v2.md` to `backend/docs/migration-v1-to-v2.md`, which resolves correctly from the repo root on GitHub. The MkDocs sidebar nav is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)