### PR TITLE
fix: disable devtools plugins in production builds

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <VueQueryDevtools />
+    <VueQueryDevtools v-if="isDev" />
     <AppNavigation />
     <v-main>
       <v-container fluid class="pa-0 pt-3 pa-sm-4">
@@ -54,6 +54,7 @@ import { useOffline } from "@/composables/offlineComposable";
 import { useRealtimeSync } from "@/composables/useRealtimeSync";
 import { version as appVersion } from "../package.json";
 
+const isDev = import.meta.env.DEV;
 const reloadPage = () => {
   window.location.reload();
 };

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,10 +6,10 @@ import { fileURLToPath, URL } from "node:url";
 import eslint from "vite-plugin-eslint";
 import { VitePWA } from "vite-plugin-pwa";
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     vue(),
-    vueDevTools(),
+    mode !== "production" && vueDevTools(),
     createHtmlPlugin({
       inject: {
         data: {
@@ -95,4 +95,4 @@ export default defineConfig({
       "@": fileURLToPath(new URL("./src", import.meta.url)),
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary
- Guard `VueQueryDevtools` with `v-if="isDev"` (`import.meta.env.DEV`) so TanStack Query's devtools plugin is never registered in production
- Conditionalize `vite-plugin-vue-devtools` to dev-mode-only in `vite.config.js`

## Root cause
`VueQueryDevtools` was rendered unconditionally in `App.vue`, which calls `setupDevtoolsPlugin` from `@vue/devtools-api` even in production builds. When a user has the Vue DevTools browser extension installed, that triggers plugin setup callbacks — including Pinia's — which calls `store._customProperties.forEach(...)`. This caused `Uncaught TypeError: Cannot read properties of undefined (reading 'forEach')` on the production sandbox.

## Test plan
- [ ] Merge and test on production sandbox — the `forEach` error should no longer appear in console
- [ ] Confirm Vue DevTools / TanStack Query devtools still work in development

🤖 Generated with [Claude Code](https://claude.com/claude-code)