### PR TITLE
fix: allow release docs deploy to be re-run manually

### DIFF
--- a/.github/workflows/deploy-docs-release.yml
+++ b/.github/workflows/deploy-docs-release.yml
@@ -3,6 +3,15 @@ name: Deploy MkDocs (Release)
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to deploy docs for (e.g. v1.3.0)"
+        required: true
+      prerelease:
+        description: "Is this a pre-release? (true/false)"
+        required: false
+        default: "false"
 
 permissions:
   contents: write
@@ -15,7 +24,7 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag_name }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -37,11 +46,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          VERSION=${{ github.event.release.tag_name }}
+          VERSION=${{ github.event.release.tag_name || inputs.tag_name }}
           VERSION=${VERSION#v}
           MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+
+          IS_PRERELEASE=${{ github.event.release.prerelease || inputs.prerelease }}
+
           mike deploy "$MAJOR_MINOR" --push --update-aliases --config-file backend/mkdocs.yml
 
-          if [[ "${{ github.event.release.prerelease }}" != "true" ]]; then
+          if [[ "$IS_PRERELEASE" != "true" ]]; then
             mike alias "$MAJOR_MINOR" latest --update-aliases --push --config-file backend/mkdocs.yml
           fi


### PR DESCRIPTION
## The live defect this repairs

The docs site currently serves **1.7 as `latest`**, while **v1.8.0 is the current release**. It has been that way since 2026-05-28 — 72 days.

`versions.json` on `gh-pages`:
```
dev []
1.8 []            ← the current release, no alias
1.7 ['latest']    ← what the docs site actually serves
```

## How it happened

The `Deploy MkDocs (Release)` run for v1.8.0 (run 26602856922) failed:

```
warning: nothing changed in commit
error: alias 'latest' already exists for version '1.7'
```

`mike deploy 1.8` succeeded, then `mike alias 1.8 latest` died for want of `--update-aliases`. The run left the versioned docs published and the alias stale — a partial success that reports as a plain failure.

The missing flag was fixed on 2026-06-01 (`ci: add --update-aliases to mike alias in release docs deploy`), but **the fix could never take effect**: this workflow triggers only on `release: published`, and v1.8.0 was already released. There was no way to re-run it.

## What this changes

Adds `workflow_dispatch` with `tag_name` / `prerelease` inputs, copied verbatim from LenoreFin's version of this workflow. After merge, the stale alias is repaired with:

```bash
gh workflow run deploy-docs-release.yml -R Novanglus96/LenoreShop \
  -f tag_name=v1.8.0 -f prerelease=false
```

The two repos' copies of this file are now identical apart from LenoreFin's `LenoreTemplate` guard and the order of two flags.

## Wider note

This is the failure mode where a job dies between publishing a versioned artifact and moving its floating alias, leaving the alias permanently stale with no alarm. It is the first confirmed instance in these repos, and it is one of the things the `lenore-ci` reusable workflow is being built to make structurally impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)