### PR TITLE
ci: run the PR title lint on a GitHub-hosted runner

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
## The exposure

These repos are **public**, and `pr-title-lint.yml` triggers on `pull_request` while running on `runs-on: self-hosted` — the runner pool on artemis2, which mounts `/var/run/docker.sock`. For a `pull_request` event the workflow that runs comes from the merge commit, so fork-authored content is in scope.

`gh-runners/docker-compose.yml` states the assumption plainly:

> anything that runs on these runners can control docker on artemis2 … Keep the repos private and treat workflow files as trusted.

The repos are no longer private. artemis2 is also a backup client holding a confined rsync key to zeus, so runner compromise is not contained to CI.

What currently stands between a stranger and that runner is a GitHub **default** — "require approval for first-time contributors" — not a deliberate control, and it does not cover a second PR from someone whose first was approved.

## The change

`runs-on: self-hosted` → `runs-on: ubuntu-latest`.

This is a title linter. It needs nothing self-hosted, and GitHub-hosted runners are free and unlimited for public repos. Trusted work (release, build, publish, docs, announce) is unaffected and stays on the self-hosted pool.

## Note on the commit type

Titled `ci:` deliberately so it does **not** trigger a semantic-release version bump. A `fix:` here would cut a release for a CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)